### PR TITLE
Adds possibility to override tag name. Fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,19 @@ Use -m to auto commit and tag. Apply optional message and
 use '%s' as placeholder for the updated version. Default
 message is 'v%s' where %s is replaced with new version.
 
---no-prefix (or -n for short) is used when you want to make
-a tag without v as prefix. This does not change behaviour of
+--tag (or -t for short) allows for overriding the tag name used. This does not
+change behaviour of the message, just the tag name. As with -m, all occurances of %s
+is replaced with the newly bumped version.
+
+--no-prefix (or -n for short) is a short hand for setting
+a tag name without v as prefix. This does not change behaviour of
 the message, just the tag name.
 
 --
 Ex: "mversion minor -m"
-Ex: "mversion minor -m 'Bumped to v%s'"
+Ex: "mversion minor -m 'Bumped to v%s' --tag 'v%s-src'"
 --
+
 ```
 
 ### Examples
@@ -177,13 +182,34 @@ Example:
 mversion.update({
   version: 'major',
   commitMessage: 'Bumps to version %s'
-})
+});
 ```
 
+#### `options.tagName : String`
+Default: `v%s`
+
+Allows for overriding of tagName. For instance adding a suffix and
+changeing tag to be named `v%s-src`.
+
+__Will only take affect if commitMessage is defined.__
+
+Occurances of `%s` in tag name will be replaced with new version number.
+
+Example:
+```javascript
+mversion.update({
+  version: 'major',
+  commitMessage: 'Bumps to version %s',
+  tagName: 'v%s-src'
+});
+// Might produce annotated tag named v1.0.0-src
+```
 
 #### `options.noPrefix : Boolean`
-If true and commitMessage is defined, the annotated tag created
-will not have 'v' as prefix.
+If true and commit message is defined, the annotated tag created
+will not have 'v' as prefix. This is a short hand for defining
+setting tag name to `%s`. Do not work if tag name is overriden
+(`options.tagName` is defined).
 
 Example:
 ```javascript
@@ -191,9 +217,19 @@ mversion.update({
   version: 'major',
   commitMessage: 'Bumps to version %s',
   noPrefix: true
-})
+});
+// Might produce annotated tag named 1.0.0
 ```
 
+This would be the same as:
+```javascript
+mversion.update({
+  version: 'major',
+  commitMessage: 'Bumps to version %s',
+  tagName: '%s'
+});
+// Might produce annotated tag named 1.0.0
+```
 
 ### `mversion.isPackageFile(filename) : Boolean`
 Checks whether or not the given filename is a valid package file type.

--- a/bin/version
+++ b/bin/version
@@ -7,6 +7,7 @@ var argv = process.argv.slice(2),
     thisVersion = require('../package.json').version;
 
 var parsedArguments = require('minimist')(argv, {
+  'string': ['t', 'tag'],
   'boolean': ['n']
 });
 var defaultMessage = "v%s";
@@ -55,6 +56,11 @@ function update () {
       parsedArguments.m === true
         ? defaultMessage
         : parsedArguments.m;
+  }
+
+  // Check for overriding tag name
+  if (isArgumentPassed('t', 'tag')) {
+    updateOptions.tagName = parsedArguments.t || parsedArguments.tag;
   }
 
   version.update(updateOptions, function (err, data) {
@@ -118,13 +124,19 @@ function usage () {
                 "message is 'v" + chalk.magenta("%s") + "' where " + chalk.magenta("%s") + " is replaced with new version.",
                 "",
 
-                chalk.yellow("--no-prefix") + " (or " + chalk.yellow("-n") + " for short) is used when you want to make",
-                "a tag without v as prefix. This does not change behaviour of",
+
+                chalk.yellow("--tag") + " (or " + chalk.yellow("-t") + " for short) allows for overriding the tag name used. This does not",
+                "change behaviour of the message, just the tag name. As with " + chalk.yellow("-m") + ", all occurances of " + chalk.magenta("%s"),
+                "is replaced with the newly bumped version.",
+                "",
+
+                chalk.yellow("--no-prefix") + " (or " + chalk.yellow("-n") + " for short) is a short hand for setting",
+                "a tag name without v as prefix. This does not change behaviour of",
                 "the message, just the tag name.",
                 "",
                 "--",
                 "Ex: \"mversion minor -m\"",
-                "Ex: \"mversion minor -m 'Bumped to v%s'\"",
+                "Ex: \"mversion minor -m 'Bumped to v%s' --tag 'v%s-src'\"",
                 "--",
                 ""
               ].join("\n"))

--- a/lib/git.js
+++ b/lib/git.js
@@ -22,7 +22,7 @@ module.exports.isRepositoryClean = function (callback) {
   });
 };
 
-module.exports.commit = function (files, message, newVer, noPrefix, callback) {
+module.exports.commit = function (files, message, newVer, tagName, callback) {
   message = message.replace('%s', newVer).replace('"', '').replace("'", '');
 
   var functionSeries = [
@@ -37,7 +37,7 @@ module.exports.commit = function (files, message, newVer, noPrefix, callback) {
     function (done) {
       cp.exec(
         [
-          gitApp, 'tag', '-a', (noPrefix ? '' : 'v') + newVer, '-m', '"' + message + '"'
+          gitApp, 'tag', '-a', tagName, '-m', '"' + message + '"'
         ].join(' '),
         gitExtra, done
       );

--- a/tests/git_test.js
+++ b/tests/git_test.js
@@ -88,17 +88,37 @@ describe('git', function () {
         return cb(null);
       };
 
-      git.commit = function (files, message, newVer, noPrefix, callback) {
+      git.commit = function (files, message, newVer, tagName, callback) {
         assert.equal(message, 'Message');
         assert.equal(newVer, '1.0.0');
         assert.equal(files[0], expectedPath);
-        assert.equal(noPrefix, false);
+        assert.equal(tagName, 'v1.0.0');
         return callback(null);
       };
 
       version.update({
         version: '1.0.0',
         commitMessage: 'Message'
+      }, function (err, data) {
+        assert.ifError(err);
+        done();
+      });
+    });
+
+    it('should be able to override tagName', function (done) {
+      git.isRepositoryClean = function (cb) {
+        return cb(null);
+      };
+
+      git.commit = function (files, message, newVer, tagName, callback) {
+        assert.equal(tagName, 'v1.0.0-src');
+        return callback(null);
+      };
+
+      version.update({
+        version: '1.0.0',
+        commitMessage: 'Message',
+        tagName: 'v%s-src'
       }, function (err, data) {
         assert.ifError(err);
         done();

--- a/version.js
+++ b/version.js
@@ -64,6 +64,10 @@ exports.update = function (options, callback) {
     };
   }
 
+  if (!options.tagName) {
+    options.tagName = (options.noPrefix ? '' : 'v') + '%s';
+  }
+
   var ver = options.version || 'minor';
   var noPrefix = !!options.noPrefix;
   var commitMessage = options.commitMessage || void 0;
@@ -131,6 +135,7 @@ exports.update = function (options, callback) {
     });
 
     stored.on('end', function () {
+
       var errorMessage = null;
       if (errors.length) {
         errorMessage = errors.map(function (e) {
@@ -154,15 +159,14 @@ exports.update = function (options, callback) {
         return void 0;
       }
 
-      git.commit(files, commitMessage, updated.version, noPrefix, function (err) {
+      var tagName = options.tagName.replace('%s', updated.version).replace('"', '').replace("'", '');
+      git.commit(files, commitMessage, updated.version, tagName, function (err) {
         if (err) {
           callback(err, null);
           return void 0;
         }
 
-        ret.message += '\nCommited to git and created tag ';
-        if (!noPrefix) ret.message += 'v';
-        ret.message += updated.version;
+        ret.message += '\nCommited to git and created tag ' + tagName;
         callback(null, ret);
       });
     });


### PR DESCRIPTION
Updates the API and CLI to allow for overriding the default tag name. Takes precedence of the `noPrefix` flag.
