### PR TITLE
run postupdate hook even if there is a postcommit hook defined

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -109,20 +109,14 @@ module.exports = function (argv, loggers, processCallback) {
       if (!rc.scripts || (!rc.scripts.postcommit && !rc.scripts.postupdate)) {
         return processCallback();
       }
-
-      if (!rc.scripts.postcommit) {
-        return runPostUpdate();
-      }
-
-      if (!updateOptions.commitMessage) {
-        return processCallback();
-      }
-
-      if (rc.scripts.postcommit) {
+      
+      if (rc.scripts.postcommit && updateOptions.commitMessage) {
         scripts.run(
           rc.scripts.postcommit.replace('%s', data.newVersion),
           scriptsCallback('postcommit', runPostUpdate)
         );
+      }else{
+        return runPostUpdate();
       }
 
       function runPostUpdate() {

--- a/tests/cli_test.js
+++ b/tests/cli_test.js
@@ -234,13 +234,15 @@ describe('cli', function() {
     });
 
     it('should execute pre- and postupdate scripts', function (done) {
+      // even if there is a postcommit script defined
       files.getRC = function () {
         return {
-          commitMessage: 'foo',
           tagName: 'bar',
           scripts: {
             preupdate: 'pre',
-            postupdate: 'post'
+            precommit: 'foo',
+            postupdate: 'post',
+            postcommit: 'foo'
           }
         };
       };


### PR DESCRIPTION
Hey I just realized that the `postupdate` hook is never executed when there variable `postcommit` is defined.

I think it would be more intuitive if we execute all hooks when the actual action happened and not whether there is an alternative hook defined. 

This PR fixes this bug and now calls `postupdate` too :)
