### PR TITLE
Use 'path.sep' instead of '/'

### DIFF
--- a/tests/package_test.js
+++ b/tests/package_test.js
@@ -108,7 +108,7 @@ describe('mversion(package.json)', function () {
       version.update('1.0.0', function (err, res) {
         assert.ok(err);
         assert.ok(err.message);
-        assert.equal(err.message, ` * fixtures${path.sep}package.json: Unexpected string`);
+        assert.equal(err.message, ' * fixtures' + path.sep + 'package.json: Unexpected string');
         assert.equal(res.versions[filename], void 0);
 
         done();

--- a/tests/package_test.js
+++ b/tests/package_test.js
@@ -108,7 +108,7 @@ describe('mversion(package.json)', function () {
       version.update('1.0.0', function (err, res) {
         assert.ok(err);
         assert.ok(err.message);
-        assert.equal(err.message, ' * fixtures/package.json: Unexpected string');
+        assert.equal(err.message, ` * fixtures${path.sep}package.json: Unexpected string`);
         assert.equal(res.versions[filename], void 0);
 
         done();


### PR DESCRIPTION
The test titled [`#Update(version) > it should give error if syntax error in package.json`](https://github.com/monoblaine/mversion/blob/6dd34b4ffc5f5f75627b0d04cc2f83868ae0dd0d/tests/package_test.js#L81) fails on Windows, because the path separator for windows is `\`. We can use `path.sep` instead of hard-coding `/`.