### PR TITLE
Stream output instead of buffering it in memory

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -143,18 +143,13 @@ module.exports = function (argv, loggers, processCallback) {
 
   function scriptsCallback (scriptType, cb) {
     cb = cb || function () {};
-    return function (err, stdout) {
-      if (err) {
-        errorLogger(chalk.red('Error running ' + scriptType + ':'), err.message);
+    return function (errCode) {
+      if (errCode) {
+        errorLogger(chalk.red('Error running ' + scriptType + ', script exited with code:'+ errCode));
         errorLogger(chalk.red('Stopping execution'));
-        cb(err);
-        return processCallback();
+        return processCallback(errCode);
       }
 
-      var str = stdout.toString('utf8');
-      if (str) {
-        logger(chalk.green('Output running ' + scriptType + ':'), str);
-      }
       cb();
     };
   }

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -1,7 +1,19 @@
-var exec = require('child_process').exec;
+var spawn = require('child_process').spawn;
 
 module.exports.run = function (script, cb) {
-  return exec(script, {
+  var process = spawn(script, {
     cwd: process.cwd()
-  }, cb);
+  });
+
+  process.stdout.on('data', function (data) {
+    console.log(data);
+  });
+
+  process.stderr.on('data', function (data) {
+    console.error(data);
+  });
+
+  return process.on('close', function (code) {
+    cb(code)
+  });
 };


### PR DESCRIPTION
Replace `exec` method for running scripts with `spawn` and stream output directly to stdout/stderr.

When using `exec`, whole script output is buffered into memory with default maximum size of 200k. If the script generates bigger output (for example larger test cases) mversion will fail with an error `Error: maxBuffer exceeded` as it is described here:
http://www.hacksparrow.com/difference-between-spawn-and-exec-of-node-js-child_process.html