### PR TITLE
updated dependencies and one assertion, tests now pass fine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "0.10"
+  - 'node'

--- a/package.json
+++ b/package.json
@@ -20,20 +20,20 @@
     "mversion": "./bin/version"
   },
   "dependencies": {
-    "chalk": "^0.5.0",
+    "chalk": "^1.1.3",
     "cli-usage": "^0.1.2",
     "contra": "^1.6.8",
-    "minimatch": "^1.0.0",
-    "minimist": "^0.2.0",
-    "rc": "^0.5.0",
-    "semver": "^4.0.3",
-    "through2": "^1.0.0",
-    "update-notifier": "^0.2.2",
-    "vinyl-fs": "^0.3.4"
+    "minimatch": "^3.0.3",
+    "minimist": "^1.2.0",
+    "rc": "^1.1.6",
+    "semver": "^5.3.0",
+    "through2": "^2.0.3",
+    "update-notifier": "^1.0.3",
+    "vinyl-fs": "^2.4.4"
   },
   "devDependencies": {
-    "istanbul": "^0.3.0",
-    "mocha": "^2.0.1",
-    "vinyl": "^0.2.3"
+    "istanbul": "^0.4.5",
+    "mocha": "^3.2.0",
+    "vinyl": "^2.0.1"
   }
 }

--- a/tests/package_test.js
+++ b/tests/package_test.js
@@ -15,7 +15,7 @@ describe('mversion(package.json)', function () {
   var original = fUtil.loadFiles;
   var dest = vinylFs.dest;
 
-  before(function () {
+  before(function () {
     vinylFs.dest = function () {
       return through.obj(function (file, enc, next) {
         this.push(file);
@@ -108,7 +108,7 @@ describe('mversion(package.json)', function () {
       version.update('1.0.0', function (err, res) {
         assert.ok(err);
         assert.ok(err.message);
-        assert.equal(err.message, ' * fixtures' + path.sep + 'package.json: Unexpected string');
+        assert.equal(err.message, ' * fixtures' + path.sep + 'package.json: Unexpected string in JSON at position 21');
         assert.equal(res.versions[filename], void 0);
 
         done();


### PR DESCRIPTION
* Minimatch was causing security alerts
* One unit test was failing upon the update, there was some string missing in the error message (it was error'ing correctly, only message was not complete)
* There was also a rogue non-breaking space

Please consider setting up [GreenKeeper](https://greenkeeper.io/) to automate the dependency management.